### PR TITLE
style/imports: add example for import ordering

### DIFF
--- a/style/imports.md
+++ b/style/imports.md
@@ -8,7 +8,23 @@ sections, in order, with a blank space between each:
 * local `use` imports
 * `pub use` imports
 
-> **[FIXME]** add example.
+For example:
+
+```rust
+// Crates.
+extern crate getopts;
+extern crate mylib;
+
+// Standard library imports.
+use getopts::{optopt, getopts};
+use std::os;
+
+// Import from a library that we wrote.
+use mylib::webserver;
+
+// Will be reexported when we import this module.
+pub use self::types::Webdata;
+```
 
 ### Avoid `use *`, except in tests. [RFC]
 


### PR DESCRIPTION
This gives an example for import ordering.

Feedback appreciated. Hopefully I followed the guidelines appropriately.
