### PR TITLE
Add useful gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Generated when running `gitbook build`
+_book/
+
+*~
+*.bak
+*.swp
+.DS_Store


### PR DESCRIPTION
`gitbook build` generates a `_book` directory for the built static html. I added it to .gitignore because it doesn't belong in version control. I also took the time to add some very common annoyances to the .gitignore as a preemptive measure.
