### PR TITLE
Decrease line lengths by one

### DIFF
--- a/style/whitespace.md
+++ b/style/whitespace.md
@@ -1,6 +1,6 @@
 # Whitespace [RFC]
 
-* Lines _should_ not exceed 80 characters, and _must_ not exceed 100 characters.
+* Lines must not exceed 99 characters.
 * Use 4 spaces for indentation, _not_ tabs.
 * No trailing whitespace at the end of lines or files.
 


### PR DESCRIPTION
Although people speak of 80, 79 is actually the number they mean, because terminals will tend to need an extra, blank line if you write 80-character-wide lines.

These changes are in line with PEP 8’s recommendations:

> Limit all lines to a maximum of 79 characters.
> 
> …
> 
> Some teams strongly prefer a longer line length. For code maintained exclusively or primarily by a team that can reach agreement on this issue, it is okay to increase the nominal line length from 80 to 100 characters (effectively increasing the maximum length to 99 characters), provided that comments and docstrings are still wrapped at 72 characters.

(We can deal with its docstrings 72 characters at another time; the wisdom of it is much more debatable.
