### PR TITLE
Not using whitespace for mid-line alignment.

### DIFF
--- a/style/whitespace.md
+++ b/style/whitespace.md
@@ -103,3 +103,31 @@ foo_bar(x, y, |z| {
 >         }
 >     }
 >     ```
+
+### Alignment
+
+Idiomatic code should not use extra whitespace in the middle of a line
+to provide alignment.
+
+
+``` rust
+// Good
+struct Foo {
+    short: f64,
+    really_long: f64,
+}
+
+// Bad
+struct Bar {
+    short:       f64,
+    really_long: f64,
+}
+
+// Good
+let a = 0;
+let radius = 7;
+
+// Bad
+let b        = 0;
+let diameter = 7;
+```


### PR DESCRIPTION
Added a section in the style/whitespace.md page suggesting that whitespace not be used in the middle of a line to create alignment in variable declarations or structs.
