### PR TITLE
reuse: add example from tutorial

### DIFF
--- a/features/traits/reuse.md
+++ b/features/traits/reuse.md
@@ -4,3 +4,27 @@
 
 > **[OPEN]** We probably want to discourage this, at least when used in a way
 > that is publicly exposed.
+
+Traits that provide default implmentations for function can provide code reuse
+across types. For example, a `print` method can be defined across multiple
+types as follows:
+
+``` Rust
+trait Printable {
+    // Default method implementation
+    fn print(&self) { println!("{:?}", *self) }
+}
+
+impl Printable for int {}
+
+impl Printable for String {
+    fn print(&self) { println!("{}", *self) }
+}
+
+impl Printable for bool {}
+
+impl Printable for f32 {}
+```
+
+This allows the implementation of `print` to be shared across types, yet
+overridden where needed, as seen in the `impl` for `String`.


### PR DESCRIPTION
This adds the example provided in the standard Rust tutorial, with a short description, to provide an example of using traits for reuse.

Perhaps we should come up with a better example than this `Printable` one, but I couldn't think of anything short enough that is actually superior for understanding the concept.

Discussion could still use elaboration, but I figure having _anything_ on this page is better than before.
