### PR TITLE
fix bulleted list in unit testing section

### DIFF
--- a/testing/unit.md
+++ b/testing/unit.md
@@ -5,6 +5,7 @@ test. Mark the `test` submodule with `#[cfg(test)]` so it is only compiled when
 testing.
 
 The `test` module should contain:
+
 * Imports needed only for testing.
 * Functions marked with `#[test]` striving for full coverage of the parent module's
   definitions.


### PR DESCRIPTION
This doesn't matter in GitHub's markdown (which doesn't care that the
bullets aren't separated by a newline), but proper spacing does matter
in Rustbook.
