### PR TITLE
Remove link to old style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # THIS REPOSITORY HAS DISCONTINUED
 
-Please see the new [Style Guidelines](https://doc.rust-lang.org/1.12.0/style/README.html) and the corresponding [fmt-rfcs](https://github.com/rust-lang-nursery/fmt-rfcs) repository.
+Please see the new [fmt-rfcs](https://github.com/rust-lang-nursery/fmt-rfcs) repository.


### PR DESCRIPTION
I believe the newest style guide is in fact at https://github.com/rust-lang-nursery/fmt-rfcs/blob/master/guide/guide.md

Removing a link to the old style guide should help direct people and their input to correct place.